### PR TITLE
Support for Vitis 2025.1

### DIFF
--- a/hls/arp_server_subnet/CMakeLists.txt
+++ b/hls/arp_server_subnet/CMakeLists.txt
@@ -1,72 +1,58 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME arp_server_subnet)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/arp_server_subnet_config.hpp.in arp_server_subnet_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/arp_server_subnet.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/arp_server_subnet.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/arp_server_subnet_config.hpp.in
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/arp_server_subnet.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/arp_server_subnet.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/arp_server_subnet_config.hpp.in)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
-                                   
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/arp_server_subnet/make.tcl.in
+++ b/hls/arp_server_subnet/make.tcl.in
@@ -1,8 +1,7 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
@@ -11,27 +10,10 @@ set_top ${PROJECT_NAME}_top
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/../axi_utils.cpp
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/arp_server_subnet.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 
-
-add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_arp_server_subnet.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
-
-
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design -clean -argv {${CMAKE_CURRENT_SOURCE_DIR}/in.dat ${CMAKE_CURRENT_SOURCE_DIR}/out.dat}
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "arp_server_subnet" -display_name "ARP Subnet Server" -description "Replies to ARP queries and resolves IP addresses." -vendor "ethz.systems.fpga" -version "1.1"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "arp_server_subnet" -display_name "ARP Subnet Server" -description "Replies to ARP queries and resolves IP addresses." -vendor "ethz.systems.fpga" -version "1.1"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/ethernet_frame_padding_512/CMakeLists.txt
+++ b/hls/ethernet_frame_padding_512/CMakeLists.txt
@@ -1,72 +1,56 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME ethernet_frame_padding_512)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/ethernet_frame_padding_512.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/ethernet_frame_padding_512.hpp
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/ethernet_frame_padding_512.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/ethernet_frame_padding_512.hpp)
-    #${CMAKE_CURRENT_SOURCE_DIR}/test_ethernet_frame_padding_512.cpp)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
-
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/ethernet_frame_padding_512/make.tcl.in
+++ b/hls/ethernet_frame_padding_512/make.tcl.in
@@ -1,6 +1,4 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
 
@@ -11,26 +9,10 @@ set_top ${PROJECT_NAME}
 
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/ethernet_frame_padding_512.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 
-
-#add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_ethernet_frame_padding_512.cpp
-
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -display_name "Ethernet Frame Padding 512" -vendor "ethz.systems.fpga" -version "0.1"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -display_name "Ethernet Frame Padding 512" -vendor "ethz.systems.fpga" -version "0.1"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/hash_table/CMakeLists.txt
+++ b/hls/hash_table/CMakeLists.txt
@@ -1,74 +1,58 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME hash_table)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-set(TCP_STACK_MAX_SESSIONS 1000 CACHE STRING "Max number of entries")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hash_table_config.hpp.in hash_table_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/hash_table.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/hash_table.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/hash_table_config.hpp.in
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/hash_table.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/hash_table.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/hash_table_config.hpp.in)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
-                                   
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/hash_table/make.tcl.in
+++ b/hls/hash_table/make.tcl.in
@@ -1,8 +1,7 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
@@ -10,26 +9,10 @@ set_top ${PROJECT_NAME}_top
 
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/hash_table.cpp -cflags "-std=c++11 -I${CMAKE_CURRENT_BINARY_DIR}"
 
-
-add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_hash_table.cpp -cflags "-std=c++11 -I${CMAKE_CURRENT_BINARY_DIR}"
-
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "hash_table" -display_name "Hash Table (cuckoo)" -description "" -vendor "ethz.systems.fpga" -version "1.0"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "hash_table" -display_name "Hash Table (cuckoo)" -description "" -vendor "ethz.systems.fpga" -version "1.0"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/icmp_server/CMakeLists.txt
+++ b/hls/icmp_server/CMakeLists.txt
@@ -1,74 +1,59 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME icmp_server)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+# set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-#set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
-
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-#configure_file(${CMAKE_CURRENT_SOURCE_DIR}/icmp_server_config.hpp.in icmp_server_config.hpp)
+# configure_file(${CMAKE_CURRENT_SOURCE_DIR}/icmp_server_config.hpp.in icmp_server_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/icmp_server.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/icmp_server.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/test_icmp_server.cpp
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/icmp_server.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/icmp_server.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_icmp_server.cpp)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
-                                   
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/icmp_server/make.tcl.in
+++ b/hls/icmp_server/make.tcl.in
@@ -1,8 +1,7 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
@@ -10,26 +9,10 @@ set_top ${PROJECT_NAME}_top
 
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/icmp_server.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 
-
-add_files -tb test_icmp_server.cpp
-
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "icmp_server" -display_name "ICMP Server" -vendor "xilinx.labs" -version "1.67"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "icmp_server" -display_name "ICMP Server" -vendor "xilinx.labs" -version "1.67"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/ip_handler/CMakeLists.txt
+++ b/hls/ip_handler/CMakeLists.txt
@@ -1,75 +1,59 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME ip_handler)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ip_handler_config.hpp.in ip_handler_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/ip_handler.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/ip_handler.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/ip_handler_config.hpp.in
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/ip_handler.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/ip_handler.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ip_handler_config.hpp.in
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_ip_handler.cpp)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
-                                   
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/ip_handler/make.tcl.in
+++ b/hls/ip_handler/make.tcl.in
@@ -1,8 +1,7 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
@@ -12,28 +11,12 @@ add_files ${CMAKE_CURRENT_SOURCE_DIR}/../axi_utils.cpp
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/../ipv4/ipv4_utils.cpp
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/ip_handler.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 
+# config_rtl -disable_start_propagation
 
-add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_ip_handler.cpp
-
-
-#config_rtl -disable_start_propagation
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design -clean
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "ip_handler" -display_name "IP Handler" -vendor "ethz.systems.fpga" -version "2.0"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "ip_handler" -display_name "IP Handler" -vendor "ethz.systems.fpga" -version "2.0"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/ipv4/CMakeLists.txt
+++ b/hls/ipv4/CMakeLists.txt
@@ -1,74 +1,61 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME ipv4)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ipv4_config.hpp.in ipv4_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipv4.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipv4.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipv4_config.hpp.in)
-    #${CMAKE_CURRENT_SOURCE_DIR}/test_ipv4.cpp)
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/ipv4.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/ipv4.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/ipv4_config.hpp.in
+)
 
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
-
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/ipv4/make.tcl.in
+++ b/hls/ipv4/make.tcl.in
@@ -1,37 +1,18 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
 set_top ${PROJECT_NAME}_top
 
-#add_files ${CMAKE_SOURCE_DIR}/../packet.hpp
-#add_files ${CMAKE_SOURCE_DIR}/ipv4.hpp
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/ipv4.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 
-
-#add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_ipv4.cpp
-
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "ipv4" -display_name "IPv4" -description "" -vendor "ethz.systems.fpga" -version "0.1"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "ipv4" -display_name "IPv4" -description "" -vendor "ethz.systems.fpga" -version "0.1"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/ipv6/CMakeLists.txt
+++ b/hls/ipv6/CMakeLists.txt
@@ -1,72 +1,59 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME ipv6)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
+   set(IPREPO_DIR $ENV{IPREPO_DIR})
+elseif(NOT IPREPO_DIR)
+   set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
+endif()
+
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ipv6_config.hpp.in ipv6_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/ipv6.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/ipv6.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/ipv6_config.hpp.in
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipv6.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipv6.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/ipv6_config.hpp.in)
-    #${CMAKE_CURRENT_SOURCE_DIR}/test_ipv6.cpp)
-
-
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
-   set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
-   set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
 endif()
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
+
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/ipv6/make.tcl.in
+++ b/hls/ipv6/make.tcl.in
@@ -1,39 +1,20 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
 set_top ${PROJECT_NAME}_top
 
-#add_files ${CMAKE_SOURCE_DIR}/../packet.hpp
-#add_files ${CMAKE_SOURCE_DIR}/ipv6.hpp
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/ipv6.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
-
-
-#add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_ipv6.cpp
-
 
 config_rtl -disable_start_propagation
 
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "ipv6" -display_name "IPv6" -description "" -vendor "ethz.systems.fpga" -version "0.1"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "ipv6" -display_name "IPv6" -description "" -vendor "ethz.systems.fpga" -version "0.1"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/mac_ip_encode/CMakeLists.txt
+++ b/hls/mac_ip_encode/CMakeLists.txt
@@ -1,75 +1,60 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME mac_ip_encode)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mac_ip_encode_config.hpp.in mac_ip_encode_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/mac_ip_encode.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/mac_ip_encode.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/mac_ip_encode_config.hpp.in
+   ${CMAKE_CURRENT_SOURCE_DIR}/test_mac_ip_encode.cpp
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/mac_ip_encode.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/mac_ip_encode.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/mac_ip_encode_config.hpp.in
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_mac_ip_encode.cpp)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
-                                   
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/mac_ip_encode/make.tcl.in
+++ b/hls/mac_ip_encode/make.tcl.in
@@ -1,37 +1,19 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
 set_top ${PROJECT_NAME}_top
 
-#add_files ${CMAKE_CURRENT_SOURCE_DIR}/../packet.hpp
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/../ipv4/ipv4_utils.cpp
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/mac_ip_encode.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 
-
-add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_mac_ip_encode.cpp
-
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design -argv {${CMAKE_CURRENT_SOURCE_DIR}/in.dat ${CMAKE_CURRENT_SOURCE_DIR}/tcp.out}
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "mac_ip_encode" -display_name "MAC IP Encoder" -vendor "ethz.systems.fpga" -version "2.0"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "mac_ip_encode" -display_name "MAC IP Encoder" -vendor "ethz.systems.fpga" -version "2.0"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/rocev2/CMakeLists.txt
+++ b/hls/rocev2/CMakeLists.txt
@@ -1,47 +1,34 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME rocev2)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake ${CMAKE_CURRENT_SOURCE_DIR}/../../../../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
-
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xcvu9p-flgb2104-3-e CACHE STRING "FPGA part")
-set(RETRANS_EN 1 CACHE STRING "Re-transmission logic enable")
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
 set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 set(PMTU_BYTES 4096 CACHE STRING "PMTU size.")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-# RoCE parameters
+set(RETRANS_EN 1 CACHE STRING "Re-transmission logic enable")
 set(ROCE_STACK_MAX_QPS 500 CACHE STRING "Maximum number of queue pairs the RoCE stack can support")
 
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation directory
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
-
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../ipv4/ipv4_config.hpp.in ipv4_config.hpp)
@@ -50,30 +37,30 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../udp/udp_config.hpp.in udp_config.h
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/rocev2_config.hpp.in rocev2_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/rocev2.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/rocev2.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/rocev2_config.hpp.in
+   ${CMAKE_CURRENT_SOURCE_DIR}/test_ib_transport.cpp
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/rocev2.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/rocev2.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rocev2_config.hpp.in
-    # ${CMAKE_CURRENT_SOURCE_DIR}/test_rocev2.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test_ib_transport.cpp
-    )
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
+add_dependencies(services services.${PROJECT_NAME})

--- a/hls/rocev2/make.tcl.in
+++ b/hls/rocev2/make.tcl.in
@@ -1,8 +1,7 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
@@ -18,31 +17,12 @@ add_files ${CMAKE_CURRENT_SOURCE_DIR}/../ib_transport_protocol/ib_utils.cpp -cfl
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/../ib_transport_protocol/ib_transport_protocol.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/rocev2.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 
+# config_rtl -disable_start_propagation
 
-# add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_rocev2.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
-add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_ib_transport.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
-# add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/test_crc.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
-
-
-#config_rtl -disable_start_propagation
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   # csim_design -argv {${CMAKE_CURRENT_SOURCE_DIR}/write_read_read_large_receiver.in ${CMAKE_CURRENT_SOURCE_DIR}/write_read_read_large_receiver.out ${CMAKE_CURRENT_SOURCE_DIR}/rdma_txwriteread.in ${CMAKE_CURRENT_SOURCE_DIR}/rdma_txwriteread.out}
-   csim_design
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "rocev2" -display_name "RoCEv2 Endpoint" -description "" -vendor "ethz.systems.fpga" -version "0.82"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip|services> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "rocev2" -display_name "RoCEv2 Endpoint" -description "" -vendor "ethz.systems.fpga" -version "0.82"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/toe/CMakeLists.txt
+++ b/hls/toe/CMakeLists.txt
@@ -1,29 +1,17 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME toe)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
 # TCP parameters
 set(TCP_STACK_MAX_SESSIONS 1000 CACHE STRING "Maximum number of sessions the TCP/IP stack can support")
 set(TCP_STACK_MSS 4096 CACHE STRING "Maximum Segment Size (MSS)")
@@ -32,66 +20,61 @@ set(TCP_STACK_RX_DDR_BYPASS_EN 1 CACHE BOOL "Enabling DDR bypass on the RX path"
 set(TCP_STACK_FAST_RETRANSMIT_EN 1 CACHE BOOL "Enabling TCP fast retransmit")
 set(TCP_STACK_WINDOW_SCALING_EN 1 CACHE BOOL "Enabling TCP window scaling option")
 
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
    set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
+elseif(NOT IPREPO_DIR)
    set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
 endif()
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+# Source files, dependencies
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/ack_delay/ack_delay.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/close_timer/close_timer.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/event_engine/event_engine.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/port_table/port_table.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/probe_timer/probe_timer.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/retransmit_timer/retransmit_timer.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/rx_app_if/rx_app_if.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/rx_app_stream_if/rx_app_stream_if.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/rx_engine/rx_engine.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/rx_sar_table/rx_sar_table.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/session_lookup_controller/session_lookup_controller.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/state_table/state_table.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/tx_app_if/tx_app_if.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/tx_app_stream_if/tx_app_stream_if.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/tx_engine/tx_engine.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/tx_sar_table/tx_sar_table.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/tx_app_interface/tx_app_interface.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/toe.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/toe.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/toe_config.hpp.in
+)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/toe_config.hpp.in toe_config.hpp)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
+endif()
 
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/ack_delay/ack_delay.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/close_timer/close_timer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/event_engine/event_engine.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/port_table/port_table.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/probe_timer/probe_timer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/retransmit_timer/retransmit_timer.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rx_app_if/rx_app_if.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rx_app_stream_if/rx_app_stream_if.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rx_engine/rx_engine.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/rx_sar_table/rx_sar_table.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/session_lookup_controller/session_lookup_controller.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/state_table/state_table.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tx_app_if/tx_app_if.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tx_app_stream_if/tx_app_stream_if.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tx_engine/tx_engine.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tx_sar_table/tx_sar_table.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/tx_app_interface/tx_app_interface.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/toe.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/toe.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/toe_config.hpp.in)
-
-
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
+add_dependencies(services services.${PROJECT_NAME})
                                    

--- a/hls/toe/make.tcl.in
+++ b/hls/toe/make.tcl.in
@@ -1,8 +1,7 @@
-
 open_project ${PROJECT_NAME}_prj
-
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
@@ -28,29 +27,12 @@ add_files ${CMAKE_CURRENT_SOURCE_DIR}/tx_sar_table/tx_sar_table.cpp -cflags "-st
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/tx_app_interface/tx_app_interface.cpp -cflags "-std=c++11 -I${CMAKE_CURRENT_BINARY_DIR}"
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/toe.cpp -cflags "-std=c++11 -I${CMAKE_CURRENT_BINARY_DIR}"
 
+# config_rtl -disable_start_propagation
 
-add_files -tb ${CMAKE_CURRENT_SOURCE_DIR}/toe_tb.cpp
-
-#config_rtl -disable_start_propagation
-
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design -clean -argv {0 ${CMAKE_CURRENT_SOURCE_DIR}/testVectors/io_fin_5.dat ${CMAKE_CURRENT_SOURCE_DIR}/testVectors/rxOutput.dat ${CMAKE_CURRENT_SOURCE_DIR}/testVectors/txOutput.dat ${CMAKE_CURRENT_SOURCE_DIR}/testVectors/rx_io_fin_5.gold}
-#   csim_design -clean -argv {0 ${CMAKE_CURRENT_SOURCE_DIR}/testVectors/mysyn2.dat ${CMAKE_CURRENT_SOURCE_DIR}/testVectors/rxOutput.dat ${CMAKE_CURRENT_SOURCE_DIR}/testVectors/txOutput.dat ${CMAKE_CURRENT_SOURCE_DIR}/testVectors/rx_io_fin_5.gold}
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "toe" -display_name "10G TCP Offload Engine" -description "TCP Offload Engine supporting 10Gbps line rate, up to 10K concurrent sessions." -vendor "ethz.systems" -version "1.6"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "toe" -display_name "10G TCP Offload Engine" -description "TCP Offload Engine supporting 10Gbps line rate, up to 10K concurrent sessions." -vendor "ethz.systems" -version "1.6"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit

--- a/hls/udp/CMakeLists.txt
+++ b/hls/udp/CMakeLists.txt
@@ -1,71 +1,60 @@
 # Author:  David Sidler (david.sidler@inf.ethz.ch)
 
 cmake_minimum_required(VERSION 3.5)
-
 set (PROJECT_NAME udp)
 project(${PROJECT_NAME})
 
 # Include custom Find<Module>.cmake scripts to enable searching for Vitis HLS
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
 
-# Without this variable set, CMake will build tests when running install
-#set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+# Project properties
+set(FPGA_PART xcu55c-fsvh2892-2L-e CACHE STRING "FPGA part")
+set(DATA_WIDTH 64 CACHE STRING "Width of data path in bytes")
+set(CLOCK_PERIOD 4 CACHE STRING "Target clock period in nanoseconds")
 
-# Generate Doxygen if available
-#find_package(Doxygen)
-#if(Doxygen_FOUND)
-#  configure_file(${CMAKE_SOURCE_DIR}/Doxyfile.in Doxyfile)
-#  add_custom_target(doxygen ALL
-#      COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile 
-#      WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-#endif()
-
-
-set(FPGA_PART xc7vx690tffg1761-2 CACHE STRING "FPGA part")
-set(DATA_WIDTH 8 CACHE STRING "Width of data path in bytes")
-set(CLOCK_PERIOD 6.4 CACHE STRING "Target clock period in nanoseconds")
-
+# Make sure Vitis HLS is installed
 find_package(VitisHLS REQUIRED)
-   if (NOT VITIS_HLS_FOUND)
+if (NOT VITIS_HLS_FOUND)
    message(FATAL_ERROR "Vitis HLS not found.")
 endif()
 
+# IP path
+if(DEFINED ENV{IPREPO_DIR})
+   set(IPREPO_DIR $ENV{IPREPO_DIR})
+elseif(NOT IPREPO_DIR)
+   set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
+endif()
+
+# Source files, dependencies
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/udp_config.hpp.in udp_config.hpp)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
 
+set(HLS_DEPENDS
+   ${CMAKE_CURRENT_SOURCE_DIR}/udp.cpp 
+   ${CMAKE_CURRENT_SOURCE_DIR}/udp.hpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/udp_config.hpp.in
+)
 
-set(EXAMPLE_HLS_DEPENDS
-    ${CMAKE_CURRENT_SOURCE_DIR}/udp.cpp 
-    ${CMAKE_CURRENT_SOURCE_DIR}/udp.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/udp_config.hpp.in)
-
-
-#Setup HLS custom targets
-set(HLS_TARGETS synthesis csim ip services)
-
-foreach (target ${HLS_TARGETS})
-   if (NOT TARGET ${target})
-      add_custom_target(${target})
-   endif()
-
-   add_custom_target(${target}.${PROJECT_NAME}
-      COMMAND ${VITIS_HLS_BINARY} -f make.tcl -tclargs ${target}
-      DEPENDS ${EXAMPLE_HLS_DEPENDS})
-   add_dependencies(${target} ${target}.${PROJECT_NAME})
-endforeach()
-
-#target dependencies
-add_dependencies(ip.${PROJECT_NAME} synthesis.${PROJECT_NAME})
-add_dependencies(services.${PROJECT_NAME} ip.${PROJECT_NAME})
-
-# Installation
-if (DEFINED ENV{IPREPO_DIR})
-   set(IPREPO_DIR $ENV{IPREPO_DIR})
-elseif(NOT  IPREPO_DIR)
-   set(IPREPO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/iprepo/)
+# 'services' target for Coyote, which runs HLS synthesis and IP export
+if (NOT TARGET services)
+   add_custom_target(services)
 endif()
-#install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip/
-#   DESTINATION ${IPREPO_DIR}/${PROJECT_NAME}/)
+
+if(VITIS_HLS_MODE STREQUAL "vitis_hls")
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} -f make.tcl
+      DEPENDS ${HLS_DEPENDS}
+   )
+else()
+   add_custom_target(
+      services.${PROJECT_NAME}
+      COMMAND ${VITIS_HLS_BINARY} --tcl make.tcl --mode hls
+      DEPENDS ${HLS_DEPENDS}
+   )
+endif()
+
+add_dependencies(services services.${PROJECT_NAME})
                                    

--- a/hls/udp/make.tcl.in
+++ b/hls/udp/make.tcl.in
@@ -1,37 +1,19 @@
-
 open_project ${PROJECT_NAME}_prj
 
 open_solution "solution1"
 set_part ${FPGA_PART}
+
 create_clock -period ${CLOCK_PERIOD} -name default
 set_clock_uncertainty ${CLOCK_UNCERTAINTY} default
 
 set_top ${PROJECT_NAME}_top
 
-#add_files ${CMAKE_CURRENT_SOURCE_DIR}/../packet.hpp
-#add_files ${CMAKE_CURRENT_SOURCE_DIR}/udp.hpp
 add_files ${CMAKE_CURRENT_SOURCE_DIR}/udp.cpp -cflags "-I${CMAKE_CURRENT_BINARY_DIR}"
 
-
-#add_files -tb test_udp.cpp
-
-
-#Check which command
-set command [lindex $argv 2]
-
-if {$command == "synthesis"} {
-   csynth_design
-} elseif {$command == "csim"} {
-   csim_design
-} elseif {$command == "ip"} {
-   export_design -format ip_catalog -ipname "udp" -display_name "UDP" -description "" -vendor "ethz.systems.fpga" -version "0.4"
-} elseif {$command == "services"} {
-   file mkdir ${IPREPO_DIR}
-   file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
-   file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
-} else {
-   puts "No valid command specified. Use vitis_hls -f make.tcl <synthesis|csim|ip> ."
-}
-
+csynth_design
+export_design -format ip_catalog -ipname "udp" -display_name "UDP" -description "" -vendor "ethz.systems.fpga" -version "0.4"
+file mkdir ${IPREPO_DIR}
+file delete -force ${IPREPO_DIR}/${PROJECT_NAME}
+file copy -force ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_prj/solution1/impl/ip ${IPREPO_DIR}/${PROJECT_NAME}/
 
 exit


### PR DESCRIPTION
From Vitis 2025.1, vitis_hls is no longer available and one should use vitis-run. To support backward compatibility, we check for both and use the one available. 

Additionally, vitis-run not longer allows the passing of TCL arguments; hence, the build target is now always _services_.