### PR TITLE
Fix TOE cmake config

### DIFF
--- a/hls/toe/CMakeLists.txt
+++ b/hls/toe/CMakeLists.txt
@@ -34,6 +34,11 @@ elseif(NOT IPREPO_DIR)
 endif()
 
 # Source files, dependencies
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/toe_config.hpp.in toe_config.hpp)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make.tcl.in make.tcl)
+
 set(HLS_DEPENDS
    ${CMAKE_CURRENT_SOURCE_DIR}/ack_delay/ack_delay.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/close_timer/close_timer.cpp


### PR DESCRIPTION
CMake needs to generate the templated files. Otherwise, Coyote with enabled TCP will not find the `make.tcl` script.

This is already done for the other folders but missing in `hls/toe`.